### PR TITLE
docs: add per-release NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,16 @@
+Known issues: <https://github.com/PredictiveEcology/Biomass_speciesData/issues>
+
+# Biomass_speciesData 1.0.5
+
+* switched the default species-layer data source from kNN to SCANFI (default year 2001 to 2020), updating input/output metadata, download logic, and references accordingly
+* reworked study-area inputs: renamed `studyAreaLarge` to `studyArea_biomassParam` and `rasterToMatchLarge` to `rasterToMatch_biomassParam`, changed `studyArea` to a `SpatVector`, now require `rasterToMatch` as an input and work in metres throughout, and simplified `.inputObjects`
+* changed default `sppEquivCol` to "LandR"
+* more robust CRS handling: use `.compareCRS()` instead of `terra::compareGeom()` since the study area may not be a terra object
+* plotting: `plotVTM` now uses `Plots()`, with adjusted `.plotInitialTime` handling
+* maintenance: raised the minimum `LandR` version, piped caching through `Cache()`, removed the `pryr` dependency, and refreshed CI (`render-module-rmd.yaml`) with rebuilt module `.Rmd`
+
+# Biomass_speciesData 1.0.4 (2024-06-06)
+
+* bumped module to 1.0.4 and raised minimum `SpaDES.core` (>= 2.1.4) and `LandR` versions
+* removed stale comments and old code
+* modernized GitHub Actions CI (new PredictiveEcology actions and fixed `Require`-based package installation) and refreshed the manual/`.Rmd`, including handling `.sslVerify` as an integer and moving `spades.inputPath` to `reproducible.destinationPath`


### PR DESCRIPTION
This adds a `NEWS.md` (previously absent or a stale stub) documenting the changes over the v3 development cycle, reconstructed from the git history and organized one section per patch-or-higher release version, newest first (dev-only `.900N` increments folded into their release). Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)