### PR TITLE
Default .useParallel to 2L instead of parallel::detectCores()

### DIFF
--- a/Biomass_speciesData.R
+++ b/Biomass_speciesData.R
@@ -75,7 +75,7 @@ defineModule(sim, list(
                           "If `NA`, a hash of `studyArea_biomassParam` will be used.")),
     defineParameter(".useCache", "character", "init", NA, NA,
                     desc = "Controls cache; caches the init event by default"),
-    defineParameter(".useParallel", "numeric", parallel::detectCores(), NA, NA,
+    defineParameter(".useParallel", "numeric", 2L, NA, NA,
                     desc = "Used in reading csv file with fread. Will be passed to `data.table::setDTthreads`.")
   ),
   inputObjects = bindrows(


### PR DESCRIPTION
`.useParallel` defaults to `parallel::detectCores()`, which over-reports on cgroup/Slurm-limited nodes and errors when used to size a PSOCK cluster on nodes with more than ~125 cores (R's socket-connection limit). Here `.useParallel` only feeds `data.table::setDTthreads` (little benefit beyond 2 threads), so this defaults it to `2L`. Callers can still pass a larger value explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)